### PR TITLE
fix: correct Open Interest data parsing from Drift API

### DIFF
--- a/src/app/api/drift/markets/clear/route.ts
+++ b/src/app/api/drift/markets/clear/route.ts
@@ -1,10 +1,10 @@
 // Development endpoint to clear market data for testing auto-refresh
 // Only available in development
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { redisHelpers } from '@/lib/redis';
 
-export async function POST(request: NextRequest) {
+async function clearMarketData() {
   // Only allow in development
   if (process.env.NODE_ENV === 'production') {
     return NextResponse.json(
@@ -37,4 +37,12 @@ export async function POST(request: NextRequest) {
       status: 500 
     });
   }
+}
+
+export async function POST() {
+  return clearMarketData();
+}
+
+export async function GET() {
+  return clearMarketData();
 }


### PR DESCRIPTION
  - Fix data structure parsing to handle Drift's response format { success: true, data: [[timestamp, "value"]] }
  - Parse latest OI value from timestamp-sorted array entries
  - Convert string OI values to numbers correctly
  - Increase API samples from 1 to 100 for reliable data retrieval
  - Add GET support to markets/clear endpoint for easier testing
  - Remove unused DriftOpenInterestResponse import

## What Changed
Brief description of the changes made

## Sprint Task
Link to related issue: Closes #[issue-number]
- [ ] Task completed according to acceptance criteria
- [ ] All tests passing
- [ ] Code reviewed and documented

## Testing
- [ ] New tests added for new functionality
- [ ] Existing tests still pass
- [ ] Manual testing completed
- [ ] No breaking changes

## Claude Code Collaboration
- **Key files changed**: List main files modified
- **Architecture impact**: Any structural changes
- **Learning notes**: Key concepts implemented

## Deployment Notes
- [ ] No migration required
- [ ] Environment variables updated (if needed)
- [ ] Ready for merge